### PR TITLE
add health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,9 @@ WORKDIR /opt/kafka
 
 EXPOSE 9092 7203
 
+ADD healthcheck.sh /opt/kafka/
+
+HEALTHCHECK --interval=5s --timeout=20s --retries=3 \
+  CMD /opt/kafka/healthcheck.sh
+
 CMD ["/opt/kafka/start.sh"]

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+unset JMX_PORT
+bin/kafka-topics.sh --zookeeper ${ZOOKEEPER_IP:-zookeeper}:${ZOOKEEPER_PORT:-2181} --list


### PR DESCRIPTION
Add a health check for the container for use with docker >= 1.12
This allows other containers which are depending on this container to start only if this container is started completely.